### PR TITLE
Skipping viewer creation when render_mode is None

### DIFF
--- a/humanoid_bench/tasks.py
+++ b/humanoid_bench/tasks.py
@@ -22,7 +22,8 @@ class Task:
         if env is None:
             return
 
-        self._env.viewer = self._env.mujoco_renderer._get_viewer(self._env.render_mode)
+        if self._env.render_mode is not None:
+            self._env.viewer = self._env.mujoco_renderer._get_viewer(self._env.render_mode)
 
     @property
     def observation_space(self):


### PR DESCRIPTION
Current code always create renderer even if users are not using rendering for their experiments. This simple PR fixes the issue